### PR TITLE
add batchdeploy and batchdelete capabilities

### DIFF
--- a/doc/using-eplapp.rst
+++ b/doc/using-eplapp.rst
@@ -15,6 +15,8 @@ The commands available are:
 + ``deploy`` - Uploads a local .mon file to EPL apps in Cumulocity IoT.
 + ``delete`` - Deletes an EPL app from Cumulocity IoT.
 + ``update`` - Updates one or more of the fields of an existing EPL app in Cumulocity IoT.
++ ``batchdeploy`` - Uploads or updates a set of local .mon files to EPL apps in Cumulocity IoT.
++ ``batchdelete`` - Deletes a set of existing EPL apps in Cumulocity IoT.
 
 All of these commands have the following *mandatory* options for connecting to your Cumulocity IoT tenant: 
 
@@ -93,3 +95,52 @@ An example of an ``update`` command where we are changing *all* of the EPL app f
 .. code-block:: shell
 
     eplapp.py update -c <url> -u <username> -p <password> -n <old_name> -w <new_name> -f <monFile> -d "new description" -s active 
+
+Batch deploying to Apama EPL Apps in Cumulocity IoT
+---------------------------------------------------
+
+The ``batchdeploy`` command has an additional *mandatory* option:
+
++ ``-f | --csvfile <file>`` - The path to the CSV file that lists the EPL Apps you wish to upload to Cumulocity IoT as an EPL app and their deployment status (either NOT_DEPLOYED ot DEPLOYED)
++ ``-d | --basepath <path>`` - The path to the directory containing the monitor files you wish to upload to Cumulocity IoT as an EPL app.
+
+The CSV file content should not have a header and e.g. look like this:
+
+::
+
+ EplAppName1,DEPLOYED
+ EplAppName2,NOT_DEPLOYED
+
+The command assumes that the monitor files in the basepath follow the scheme <eplappname>.mon
+
+Thus, the minimal command for deploying to Apama EPL Apps would look like the following:
+
+.. code-block:: shell
+
+    eplapp.py batchdeploy -c <url> -u <username> -p <password> -f <csvfile> -d <directory>
+
+This would upload an active EPL app with no description and the same name as the .mon file specified.
+
+The ``batchdeploy`` command also has the following *optional* option:
+
++ ``-r | --redeploy`` - Overwrites the contents of an existing EPL app of name specified by the ``--name`` option.
+
+Batch deleting EPL apps
+-----------------------
+
+The ``batchdelete`` command has an additional *mandatory* option:
+
++ ``-f | --csvfile <file>`` -  The path to the CSV file that lists the EPL Apps you wish to delete from Cumulocity IoT
+
+The batch delete only requires the name of the EPL Apps, thus it is actually sufficient to put one EPL App name per line
+
+::
+
+ EplAppName1
+ EplAppName2
+
+For example:
+
+.. code-block:: shell
+
+    eplapp.py delete -c <url> -u <username> -p <password> -f <filename>

--- a/scripts/eplapp.py
+++ b/scripts/eplapp.py
@@ -209,6 +209,54 @@ class EPLAppsCLI:
 				],
 				function=EPLApps.update,
 				successMessage='EPL app was successfully updated.'
+			),
+			'batchdeploy': EPLAppsCLI.Command(
+				name='batchdeploy',
+				description='Deploys a set of EPL (.mon) files listed in a csv to Apama EPL Apps in Cumulocity IoT',
+				usages=[
+					'eplapp.py batchdeploy <--cumulocity_url URL> <--username USERNAME> <--password PASSWORD> <--csvfile CSVFILE> <--basepath BASEPATH> [option]*',
+					'eplapp.py batchdeploy [--help]'
+					'eplapp.py batchdeploy [--version]'
+				],
+				mandatoryOptionsMessage='Mandatory options for deploying a set of file to Apama EPL Apps:',
+				mandatoryOptions=[
+					['-c', '--cumulocity_url', 'URL', 'the base URL of your Cumulocity IoT tenant'],
+					['-u', '--username', 'USERNAME', 'your Cumulocity IoT username'],
+					['-p', '--password', 'PASSWORD', 'your Cumulocity IoT password'],
+					['-f', '--csvfile', 'CSVFILE',
+						'the filepath to the csv file listing all the EPLApps to be deployed.'
+						'The csv rows must be of format [eplappname, deploymentstatus] and should not contain a header. '
+						'The deployment status can be either NOT_DEPLOYED or DEPLOYED'],
+					['-d', '--basepath', 'BASEPATH', 'the folder containing all the monitor files to be deployed.'
+													 'The files must be named [eplappname].mon for each entry in the csv file.']
+				],
+				optionalOptionsMessage='Optional options for deploying a file to Apama EPL Apps:',
+				optionalOptions=[
+					['-r', '--redeploy', 'REDEPLOY', 'overwrite the contents of an existing EPL app']
+				],
+				function=EPLApps.batchdeploy,
+				arguments={'redeploy': True},  # Only need to supply default option arguments
+				successMessage='EPL apps command executed successfully.'
+			),
+			'batchdelete': EPLAppsCLI.Command(
+				name='batchdelete', description='Deletes all existing EPL apps given in a CSV file from Cumulocity IoT',
+				usages=[
+					'eplapp.py batchdelete <--cumulocity_url URL> <--username USERNAME> <--password PASSWORD> <--csvfile CSVFILE> ',
+					'eplapp.py batchdelete [--help]'
+					'eplapp.py batchdelete [--version]'
+				],
+				mandatoryOptionsMessage='Mandatory options for batch deleting EPL apps:',
+				mandatoryOptions=[
+					['-c', '--cumulocity_url', 'URL', 'the base URL of your Cumulocity IoT tenant'],
+					['-u', '--username', 'USERNAME', 'your Cumulocity IoT username'],
+					['-p', '--password', 'PASSWORD', 'your Cumulocity IoT password'],
+					['-f', '--csvfile', 'CSVFILE',
+						'the filepath to the csv file listing all the EPLApps to be deployed.'
+						'The csv rows must be of format [eplappname, deploymentstatus] and should not contain a header. '
+						'The deployment status can be either NOT_DEPLOYED or DEPLOYED']
+				],
+				function=EPLApps.batchdelete,
+				successMessage='EPL apps command executed successfully.'
 			)
 		}
 

--- a/testframework/apamax/eplapplications/eplapps.py
+++ b/testframework/apamax/eplapplications/eplapps.py
@@ -107,7 +107,7 @@ class EPLApps:
 			status = row[1]
 			try:
 				self.deploy(file=os.path.join(basepath, eplappname + ".mon"), name=eplappname,
-							inactive=(status != "NOT_DEPLOYED"), redeploy=redeploy)
+							inactive=(status != "DEPLOYED"), redeploy=redeploy)
 				print(f'Deployed {eplappname}')
 			except Exception as err:
 				print(err)


### PR DESCRIPTION
This adds batchdeploy and batchdelete commands to the epl tool.

The idea is to automate the process of creating and deleting multiple EPL Apps by have a single file that contains the list of files (i.e. EPL Apps) along their desired deployment status.
"batchdeploy" just iterates over the list and tries to upload the files with the corresponding names- either creating, updating (if redeploy is not set false) or skipping (in case any error occurs) the EPL App 

`eplapp.cmd batchdeploy -c https://lora-sandbox.eu-latest.cumulocity.com -u mario.heidenreich@softwareag.com -p <password> -f C:\Users\MARH\workspace\allrules.csv -d C:\Users\MARH\workspace\monitors`

"batchdelete" just takes a list of EPL App names (one per line or in the same format as batchdeploy) and tries to delete every EPL App from the target tenant from this list

`eplapp.cmd batchdelete -c https://lora-sandbox.eu-latest.cumulocity.com -u mario.heidenreich@softwareag.com -p <password> -f C:\Users\MARH\workspace\allrules.csv`